### PR TITLE
Added support for passing a function as an error message

### DIFF
--- a/jquery.expect.js
+++ b/jquery.expect.js
@@ -286,19 +286,19 @@
    * Performs an assertion
    * 
    * @param {Boolean} truth
-   * @param {String}{Function} msg
+   * @param {String|Function} msg
    * @param {String} error
    * @api private
    */
 
   Assertion.prototype.assert = function (truth, msg, error) {
+    var ok = this.flags.not ? !truth : truth;
+
+    if ($.isFunction(msg)) {
+      error = msg = msg.call(this, ok);
+    }
 	
-	if ($.isFunction(msg)) {
-		msg = msg()
-	}
-	
-    var msg = this.flags.not ? error : msg
-      , ok = this.flags.not ? !truth : truth;
+    msg = this.flags.not ? error : msg;
 
     if (!ok) {
       throw new AssertionError(msg);

--- a/test/test.js
+++ b/test/test.js
@@ -394,4 +394,15 @@ describe('$expect', function () {
     }, 'foobar');
   });
 
+  it('should test passing function as message', function () {
+    err(function () {
+      $expect('div').not.to.exist(function (truth) {
+        expect(this).to.be.a($expect.Assertion);
+        expect(this.obj).to.be.a($);
+        $expect(this.obj).to.be.eql('div');
+        expect(truth).to.not.be.ok();
+        return 'foo bar error';
+      });
+    }, 'foo bar error');
+  });
 });


### PR DESCRIPTION
Hey Amjad,

For some tests I've written, every path out of the test goes through a function that does some cleanup.

This change makes it possible to pass a function (that should return a string) as an error message that gets executed on the assertion.

I'm not too familiar with the codebase, so it is very possible that this change requires more changes than just this one.
