### PR TITLE
Adding Component.js Support via component.json (and commonjs require/export)

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,13 @@
+{
+  "name": "jquery-expect",
+  "repo": "Codeacademy/jquery-expect",
+  "description": "DOM Assertion library",
+  "keywords": [ "jQuery", "test", "DOM", "assertion", "expect" ],
+  "version": "0.0.3",
+  "license": "MIT",
+  "main": "jquery.expect.js",
+  "scripts": [ "jquery.expect.js" ],
+  "dependencies": {
+    "component/jquery": "*"
+  }
+}

--- a/jquery.expect.js
+++ b/jquery.expect.js
@@ -12,6 +12,11 @@
     return new Assertion(obj);
   }
 
+  if (window.require && !jQuery) {
+    jQuery = $ = require("jquery");
+    module.exports = $expect;
+  }
+
   /**
    * Utilities
    */


### PR DESCRIPTION
Just wanting to get [Component.js](https://github.com/component/component/blob/master/Readme.md) support, so I added the `component.json` and added a CommonJS `require` and `export`.
