### PR TITLE
Assertion.prototype.html should `return this`

### DIFF
--- a/jquery.expect.js
+++ b/jquery.expect.js
@@ -790,6 +790,7 @@
         (got = this.obj.html()) === html
       , msg || 'expected ' + inspect(this.obj) + ' to have HTML ' + html + ' but got ' + got
       , msg || 'expected ' + inspect(this.obj) + ' not to have HTML ' + html);
+    return this;
   };
 
   /**


### PR DESCRIPTION
Assertion.prototype.html should `return this` just like Assertion.prototype.text and Assertion.prototype.contain.